### PR TITLE
Speed up unit tests from 21s to 8ms by mocking call to time().

### DIFF
--- a/tests/ratelimitingfilter_test.py
+++ b/tests/ratelimitingfilter_test.py
@@ -1,12 +1,16 @@
 import os
-import time
 from unittest.case import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from ratelimitingfilter import RateLimitingFilter
 
 
 class RateLimitingFilterTest(TestCase):
+    def setUp(self):
+        patcher = patch('ratelimitingfilter.ratelimitingfilter.time')
+        self.mock_time = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.mock_time.return_value = 0
 
     def test_limit_to_one_record_per_second(self):
         f = RateLimitingFilter(rate=1, per=1, burst=1)
@@ -65,7 +69,7 @@ class RateLimitingFilterTest(TestCase):
 
         for _ in range(20):
             result.append(f.filter(mock_record))
-            time.sleep(0.1)
+            self.mock_time.return_value += 0.1
 
         return result
 
@@ -78,7 +82,7 @@ class RateLimitingFilterTest(TestCase):
             mock_record.msg = 'test message'
             if f.filter(mock_record):
                 filtered.append(mock_record)
-            time.sleep(0.1)
+            self.mock_time.return_value += 0.1
 
         self.assertEqual(len(filtered), 6)
         self.assertTrue(filtered[4].msg.endswith(os.linesep + '... 6 additional messages suppressed'))
@@ -101,7 +105,7 @@ class RateLimitingFilterTest(TestCase):
                 result.append(mock_matching_record.msg)  # Only 2 of these get logged as they match the substring
             if f.filter(mock_non_matching_record):
                 result.append(mock_non_matching_record.msg)  # 20 of these get logged as they don't match
-            time.sleep(0.1)
+            self.mock_time.return_value += 0.1
 
         self.assertEqual(len([m for m in result if 'a rate limited test message' in m]), 2)
         self.assertEqual(result.count('a different test message'), 20)
@@ -126,7 +130,7 @@ class RateLimitingFilterTest(TestCase):
             if f.filter(mock_rate_limited_record):
                 # Only 2 of these get logged as they are the all identical
                 result.append(mock_rate_limited_record.msg)
-            time.sleep(0.1)
+            self.mock_time.return_value += 0.1
 
         self.assertEqual(len([m for m in result if 'a rate limited varying message' in m]), 2)
         self.assertEqual(len([m for m in result if 'a completely different message' in m]), 2)


### PR DESCRIPTION
Thanks for sharing the project. I'm going to include it in our project, but I didn't want to slow down our test suite with all the calls to sleep. Here's a test that never sleeps.