### PR TITLE
Fixed reference to this module in __init__

### DIFF
--- a/ratelimitingfilter/__init__.py
+++ b/ratelimitingfilter/__init__.py
@@ -1,1 +1,1 @@
-from ratelimitingfilter.ratelimitingfilter import RateLimitingFilter
+from ratelimitingfilter import RateLimitingFilter


### PR DESCRIPTION
This module wouldn't work for me unless I modified the __init__ function.

For reference:
http://effbot.org/pyfaq/what-is-init-py-used-for.htm