### PR TITLE
Bugfix using the getMessage method to get a LogRecord msg as a string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
     test_suite='nose.collector',
     tests_require=['mock==2.0'],
     url='https://github.com/wkeeling/ratelimitingfilter',
-    version='1.2',
+    version='1.3',
 )

--- a/tests/ratelimitingfilter_test.py
+++ b/tests/ratelimitingfilter_test.py
@@ -100,6 +100,7 @@ class RateLimitingFilterTest(TestCase):
         for _ in range(30):
             mock_record = Mock()
             mock_record.msg = 'test message'
+            mock_record.getMessage.return_value = 'test message'
             if f.filter(mock_record):
                 filtered.append(mock_record)
             self.mock_time.return_value += 0.1
@@ -114,8 +115,10 @@ class RateLimitingFilterTest(TestCase):
 
         mock_matching_record = Mock()
         mock_matching_record.msg = 'a rate limited test message'
+        mock_matching_record.getMessage.return_value =  'a rate limited test message'
 
         mock_non_matching_record = Mock()
+        mock_non_matching_record.getMessage.return_value = 'a different test message'
         mock_non_matching_record.msg = 'a different test message'
 
         result = []
@@ -139,9 +142,11 @@ class RateLimitingFilterTest(TestCase):
         for i in range(20):
             mock_varying_record = Mock()
             mock_varying_record.msg = 'a rate limited varying message: {varying}'.format(varying=i)
+            mock_varying_record.getMessage.return_value =  'a rate limited varying message: {varying}'.format(varying=i)
 
             mock_rate_limited_record = Mock()
             mock_rate_limited_record.msg = 'a completely different message'
+            mock_rate_limited_record.getMessage.return_value = 'a completely different message'
 
             if f.filter(mock_varying_record):
                 # Only 2 of these get logged as they are considered the same message,
@@ -158,7 +163,8 @@ class RateLimitingFilterTest(TestCase):
     def test_log_exception(self):
         logger = logging.getLogger('test')
         handler = logging.StreamHandler()
-        throttle = RateLimitingFilter(rate=1, per=1, burst=1)
+        config = {'match': 'auto'}
+        throttle = RateLimitingFilter(rate=1, per=1, burst=1, **config)
         handler.addFilter(throttle)
         logger.addHandler(handler)
 


### PR DESCRIPTION
Pull request to fix a bug in the Ratelimitingfilter.

I noticed a bug when I attempted to call `logger.exception(ValueError("This is a error"))` . This is because in ratelimitingfilter.py, the log message is extracted from the LogRecord using LogRecord.msg. However, ratelimitingfilter assumes that this msg is always a string. This is not actually the case, particularly when it comes to exceptions. 

Documentation on this can be found here: https://docs.python.org/3.9/howto/logging.html#arbitrary-object-messages

For example, change the last test in the code to the following:
```python
def test_log_exception(self):
    logger = logging.getLogger('test')
    handler = logging.StreamHandler()
    ### Added configuration ###
    config = {'match': 'auto'}
    throttle = RateLimitingFilter(rate=1, per=1, burst=1, **config)
    ###########################
    handler.addFilter(throttle)
    logger.addHandler(handler)

    try:
        logger.error('First')
        raise RuntimeError('Expected exception')
    except RuntimeError as e:
        logger.exception(e)  # Should be throttled
```

And run the tests, you'll see the bug. Ratelimitingfilterfails at any point when it assumes that the msg is a string and attempts to iterate through it, as the LogRecord.msg is actually the RuntimeError exception object and is not iterable.

To fix this bug, I have changed references to LogRecord.msg to LogRecord.getMessage(), which runs __str__ on the message before passing it to you. Details on the method are here: https://docs.python.org/3.9/library/logging.html#logging.LogRecord.getMessage

I have also doubled checked, and even with the changes I still get the full stack trace when logging an exception.
