### PR TITLE
Use deprecated mock only on Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
 from setuptools import setup
+from sys import version_info
+
+if version_info.major < 3 or \
+  (version_info.major == 3 and version_info.minor < 4):
+    tests_require=['mock']
+else:
+    tests_require=[]
 
 setup(
     author='Will Keeling',
@@ -26,7 +33,7 @@ setup(
     name='ratelimitingfilter',
     packages=['ratelimitingfilter'],
     test_suite='tests',
-    tests_require=['mock'],
+    tests_require=tests_require,
     url='https://github.com/wkeeling/ratelimitingfilter',
     version='1.5',
 )

--- a/tests/ratelimitingfilter_test.py
+++ b/tests/ratelimitingfilter_test.py
@@ -3,7 +3,10 @@ from __future__ import division
 import logging
 import os
 from unittest.case import TestCase
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from ratelimitingfilter import RateLimitingFilter
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ setenv =
 deps =
     coverage
     nose
-    mock
+    py27: mock
 commands = nosetests --with-coverage --cover-erase tests


### PR DESCRIPTION
`unittest.mock` has been part of the Python standard library since Python 3.3.

Only install the old `mock` in the `py2.7` tox target, and edit the test file to prefer `unittest.mock` and fall back to `mock` as Python 2.7 has been EOL since January 1, 2020 anyway: https://www.python.org/doc/sunset-python-2/